### PR TITLE
Update node version from 12 to 16.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: ''
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/index.js'
 branding:
   icon: 'package'


### PR DESCRIPTION
Node 12 has been out of support since April 2022 we need to update version i.e Node 16.
Closes #2 